### PR TITLE
Add missing part for the thread option added in 4.3-dev.3

### DIFF
--- a/addons/scorm/export-godot_v4.3.html
+++ b/addons/scorm/export-godot_v4.3.html
@@ -455,6 +455,7 @@ a passing score rather than hard coding the passing score within the content.
 <script src="$GODOT_URL"></script>
 <script>
     const GODOT_CONFIG = $GODOT_CONFIG;
+    const GODOT_THREADS_ENABLED = $GODOT_THREADS_ENABLED;
     const engine = new Engine(GODOT_CONFIG);
 
     (function () {
@@ -532,32 +533,55 @@ a passing score rather than hard coding the passing score within the content.
             initializing = false;
         }
 
-        const missing = Engine.getMissingFeatures();
-        if (missing.length !== 0) {
-            const missingMsg = 'Error\nThe following features required to run Godot projects on the Web are missing:\n';
-            displayFailureNotice(missingMsg + missing.join('\n'));
-        } else {
-            setStatusMode('indeterminate');
-            engine.startGame({
-                'onProgress': function (current, total) {
-                    if (total > 0) {
-                        statusProgressInner.style.width = `${(current / total) * 100}%`;
-                        setStatusMode('progress');
-                        if (current === total) {
-                            // wait for progress bar animation
-                            setTimeout(() => {
-                                setStatusMode('indeterminate');
-                            }, 500);
-                        }
-                    } else {
-                        setStatusMode('indeterminate');
-                    }
-                },
-            }).then(() => {
-                setStatusMode('hidden');
-                initializing = false;
-            }, displayFailureNotice);
-        }
+        const missing = Engine.getMissingFeatures({
+		threads: GODOT_THREADS_ENABLED,
+	    });
+    	if (missing.length !== 0) {
+    		if (GODOT_CONFIG['serviceWorker'] && GODOT_CONFIG['ensureCrossOriginIsolationHeaders'] && 'serviceWorker' in navigator) {
+    			// There's a chance that installing the service worker would fix the issue
+    			Promise.race([
+    				navigator.serviceWorker.getRegistration().then((registration) => {
+    					if (registration != null) {
+    						return Promise.reject(new Error('Service worker already exists.'));
+    					}
+    					return registration;
+    				}).then(() => engine.installServiceWorker()),
+    				// For some reason, `getRegistration()` can stall
+    				new Promise((resolve) => {
+    					setTimeout(() => resolve(), 2000);
+    				}),
+    			]).catch((err) => {
+    				console.error('Error while registering service worker:', err);
+    			}).then(() => {
+    				window.location.reload();
+    			});
+    		} else {
+    			// Display the message as usual
+    			const missingMsg = 'Error\nThe following features required to run Godot projects on the Web are missing:\n';
+    			displayFailureNotice(missingMsg + missing.join('\n'));
+    		}
+    	} else {
+    		setStatusMode('indeterminate');
+    		engine.startGame({
+    			'onProgress': function (current, total) {
+    				if (total > 0) {
+    					statusProgressInner.style.width = `${(current / total) * 100}%`;
+    					setStatusMode('progress');
+    					if (current === total) {
+    						// wait for progress bar animation
+    						setTimeout(() => {
+    							setStatusMode('indeterminate');
+    						}, 500);
+    					}
+    				} else {
+    					setStatusMode('indeterminate');
+    				}
+    			},
+    		}).then(() => {
+    			setStatusMode('hidden');
+    			initializing = false;
+    		}, displayFailureNotice);
+    	}
     }());
 </script>
 </body>


### PR DESCRIPTION
The 4.3-dev.3 Godot version brought to us the ability to run the web exported game in single-thread mode (https://github.com/godotengine/godot/pull/85939). They did changes in the html template that affects the use of this option. This PR brings in these changes from [here](https://github.com/adamscott/godot/blob/master/misc/dist/html/full-size.html).

